### PR TITLE
Fix 'TypeError: Invalid non-string/buffer chunk' when using classic style streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ function pauseStreams (streams, options) {
     }
     streams.pause()
   } else {
-    for (var i = 0, len = streams.length; i < len; i++) streams[i] = pauseStreams(streams[i])
+    for (var i = 0, len = streams.length; i < len; i++) streams[i] = pauseStreams(streams[i], options)
   }
   return streams
 }


### PR DESCRIPTION
Hi,
I discovered an issue when using classic style streams.
The `options`, which should include `objectMode: true` are not defined when creating the `PassThrough` stream for compatibility with the old style streams.
Therefore, if the old style stream emits anything other than a string/Buffer, this Exception will be thrown:
```
TypeError: Invalid non-string/buffer chunk
```

Added a test to reproduce and a fix.

Thanks!