### PR TITLE
fix: add extension to main script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "license": "MIT",
   "version": "1.2.4",
-  "main": "./index",
+  "main": "./index.js",
   "jsnext:main": "index.mjs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When using merge2 in a Rollup project, it can't resolve the module. Adding the `.js` extension fixes it.