### PR TITLE
emit errors from streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Type: `Object`.
 
 * **end** - `Boolean` - if `end === false` then mergedStream will not be auto ended, you should end by yourself. **Default:** `undefined`
 
+* **pipeError** - `Boolean` - if `pipeError === true` then mergedStream will emit `error` event from source streams. **Default:** `undefined`
+
 * **objectMode** - `Boolean` . **Default:** `true`
 
 `objectMode` and other options(`highWaterMark`, `defaultEncoding` ...) is same as Node.js `Stream`.

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ function merge2 () {
   else options = {}
 
   const doEnd = options.end !== false
+  const doPipeError = options.pipeError === true
   if (options.objectMode == null) options.objectMode = true
   if (options.highWaterMark == null) options.highWaterMark = 64 * 1024
   const mergedStream = PassThrough(options)
@@ -64,9 +65,13 @@ function merge2 () {
 
       stream.on('merge2UnpipeEnd', onend)
       stream.on('end', onend)
-      stream.on('error', function (err) {
-        mergedStream.emit('error', err)
-      })
+
+      if (doPipeError) {
+        stream.on('error', function (err) {
+          mergedStream.emit('error', err)
+        })
+      }
+
       stream.pipe(mergedStream, { end: false })
       // compatible for old stream
       stream.resume()

--- a/index.js
+++ b/index.js
@@ -64,6 +64,9 @@ function merge2 () {
 
       stream.on('merge2UnpipeEnd', onend)
       stream.on('end', onend)
+      stream.on('error', function (err) {
+        mergedStream.emit('error', err)
+      })
       stream.pipe(mergedStream, { end: false })
       // compatible for old stream
       stream.resume()

--- a/test/index.js
+++ b/test/index.js
@@ -50,7 +50,7 @@ function test (merge2) {
     tman.it('merge2 - error handling', function (done) {
       const ts = through.obj()
 
-      const mergeStream = merge2(toThrough(ts))
+      const mergeStream = merge2(toThrough(ts), { pipeError: true })
 
       const expectedError = new Error('error')
       thunk.delay(100)(function () {

--- a/test/index.js
+++ b/test/index.js
@@ -47,6 +47,26 @@ function test (merge2) {
         })
     })
 
+    tman.it('merge2 - error handling', function (done) {
+      const ts = through.obj()
+
+      const mergeStream = merge2(toThrough(ts))
+
+      const expectedError = new Error('error')
+      thunk.delay(100)(function () {
+        ts.destroy(expectedError)
+      })
+
+      mergeStream
+        .on('error', function (error) {
+          assert.strictEqual(error, expectedError)
+          done()
+        })
+        .on('end', function () {
+          throw Error('error expected')
+        })
+    })
+
     tman.it('merge2(TransformStream)', function (done) {
       const result = []
       const ts = through.obj()


### PR DESCRIPTION
Errors should be emitted to the merged stream, otherwise, all errors will be encountered as an unhandled error.

Using this approach it is possible to handle errors using `stream.pipeline(merge2(stream1, stream2), outStream)` for example.